### PR TITLE
Update: github action trigger condition

### DIFF
--- a/.github/workflows/azure-static-web-apps-zealous-ocean-0bb043e1e.yml
+++ b/.github/workflows/azure-static-web-apps-zealous-ocean-0bb043e1e.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.repository_owner == 'openstack-kr'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
## WHY

* 불필요한 Github Action 트리거 로직 수정
* 제거해야할 트리거 엣지케이스 ( fork 떠서 커밋을 푸시한는 경우)
* manual trigger

## HOW (PR을 통해 어떤 부분을 수정하고자 하는가)
```yaml
if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') 
```
현재 job의 if condition이 위와 같이 설정되어있습니다. 아마 푸시 이벤트거나 PR인데 PR를 닫는 게 아니라 머지하는 경우를 trigger하려는 로직으로 보여집니다.

하지만 PR을 Merge하거나 Stash하는 것도 결국 commit이 생기고 Push가 되므로 push 만으로도 충분히 트리거 될 것입니다.

![image](https://user-images.githubusercontent.com/33250725/92349551-6c2f5200-f111-11ea-9653-8e07e6e8381d.png)

또한 무엇보다 개개인의 포크 레포지토리에서도 푸시를 할 때마다 Action이 돌고 사진처럼 X 마크가 달리게 되는데, 이 부분에 로직을 추가해서
repository owner가 개개인이 아닌 openstack-kr인 경우에만 트리거하도록 설정했습니다.

추가로 2020.07 쯤부터 Manual trigger가 추가되어 이 부분은 혹시 유용할까싶어 추가해보았습니다.(Actions 탭에서 workflow를 클릭해서 사용 가능)

## Related Issues

.
## Checklist (확인 사항)

.

- [x] I signed the CLA. (라이선스 동의 여부 - Apache License를 따릅니다)
- [ ] I listed the related issues. (관련 이슈를 제시하여 연결하였습니다)
- [x] I am willing to follow-up on review comments in a timely manner. (리뷰 내용을 잘 따르고자 합니다)

